### PR TITLE
Allow the library to work as a merged component

### DIFF
--- a/SharpKml/Base/KmlFactory.cs
+++ b/SharpKml/Base/KmlFactory.cs
@@ -116,7 +116,7 @@ namespace SharpKml.Base
 
         private static void RegisterAssembly(Assembly assembly)
         {
-            foreach (var type in assembly.GetExportedTypes())
+            foreach (var type in assembly.GetTypes())
             {
                 if (type.IsSubclassOf(typeof(Element)))
                 {


### PR DESCRIPTION
Fixes as issue created if SharpKml is merged into an assembly that
depends on it. In this case 'assembly' refers to the assembly using
SharpKml. The element types will not resolve correctly unless they are
included in the publicly exported types of dependent assembly. This
small change means that all types will be returned from the assembly,
but will still be filtered for sub-classes of Element, hence
RegisterAssembly performs as designed, but in the merged assembly
environment.